### PR TITLE
Rearrange some data to have more realistic testing scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ Both the *origin, destination* params accept either port codes or region slugs, 
     [
         {
             "day": "2016-01-01",
-            "average_price": 129
+            "average_price": 1112
         },
         {
             "day": "2016-01-02",
-            "average_price": null
+            "average_price": 1112
         },
         {
             "day": "2016-01-03",
-            "average_price": 215
+            "average_price": null
         },
         ...
     ]

--- a/rates.sql
+++ b/rates.sql
@@ -56987,3 +56987,8 @@ ALTER TABLE ONLY regions
 -- PostgreSQL database dump complete
 --
 
+-- Make Jan 3 have no prices at all
+DELETE FROM prices WHERE day = date'2016-01-03';
+-- Make Jan 4 have one price on CNSGH to GBFXT (grandchild of NE main)
+DELETE FROM prices WHERE day = date'2016-01-04';
+INSERT INTO prices VALUES ('CNSGH', 'GBFXT', date'2016-01-04', 100500);


### PR DESCRIPTION
This change removes data on 2016-01-03 and leaves only one price on 2016-01-04,
which should create more realistic-looking data and allow for testing of edge
cases easier.